### PR TITLE
displayName fix

### DIFF
--- a/src/context/LoginContext.js
+++ b/src/context/LoginContext.js
@@ -24,9 +24,7 @@ const LoginContextProvider = (props) => {
       //check if same psw was given both times at registration
       if (regpassword === regpassword2) {
         auth.createUserWithEmailAndPassword(regemail, regpassword).then(function (result) {
-          return result.user.updateProfile({
-            displayName: regname,
-          });
+          updateProfile(result.user)
         }).catch(function (error) {
           console.log(error);
         });
@@ -34,9 +32,23 @@ const LoginContextProvider = (props) => {
         console.log('passwords dont match');
       }
     };
-
+    const updateProfile = (user) => {
+      user.updateProfile({
+        displayName: regname,
+      }).then(() => {
+        // after updating profile you need to manually set the name and userId because the function onAuthStateChanged
+        //is not waiting for the profile to be updated and it runs before you add the displayName
+        const currentUser = auth.currentUser
+        setIsLoggedIn(true);
+        setName(currentUser.displayName);
+        setUserId(currentUser.uid);
+      }).catch(function(error) {
+        console.log('error', error)
+      });
+    }
   //check user status, if no user logged in, it returns null
   auth.onAuthStateChanged(user=> {
+    console.log('user', user)
     if (user) {
       setIsLoggedIn(true);
       //get name of user, and save it


### PR DESCRIPTION
Hi Zsuzsa, I fixed the displayName problem. The problem was that the onAuthStateChanged function was not waiting for the profile to be updated with the displayName, so when registering sometimes it would run before having the displayName in the user profile. Check this link: https://firebase.google.com/docs/auth/web/manage-users 
Under "Get the currently signed-in user" it says that the onAuthStateChanged observer waits until the getRedirectResult function resolves before triggering when using signInWithRedirect (which you would use when signing in through a provider such as Google). In your case you are using the normal email and password authentication, therefore the observer wasn't waiting for your update to finish.